### PR TITLE
Improve linux default key

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,5 +1,5 @@
 [
-  {
-    "keys": ["ctrl+shift+l"], "command": "list_less_variables"
-  }
+	{
+	    "keys": ["ctrl+shift+à"], "command": "list_less_variables"
+	},
 ]


### PR DESCRIPTION
Change to ctrl+shift+à to not override split_selection_into_lines